### PR TITLE
Add cryptomatte support and update for V-Ray 5 SDK

### DIFF
--- a/src/geomalembicreader.cpp
+++ b/src/geomalembicreader.cpp
@@ -465,7 +465,7 @@ VRayPlugin* GeomAlembicReader::createDefaultMaterial(void) {
 const tchar *ignoredPlugins[]={
 	"Settings",
 	"Geom",
-	"RenderView"
+	"RenderView",
 	"Camera",
 	"Node",
 	"Light",

--- a/src/geomalembicreader.cpp
+++ b/src/geomalembicreader.cpp
@@ -1,9 +1,12 @@
 #include "geomalembicreader.h"
+#include "getenvvars.h"
 
 using namespace VR;
 
 //*************************************************************
 // GeomAlembicReaderInstance
+
+static VR::GetEnvVarInt gEnvARRRI("ARRRI", 0);
 
 struct GeomAlembicReaderInstance: VRayStaticGeometry {
 	GeomAlembicReaderInstance(GeomAlembicReader *abcReader):reader(abcReader) {
@@ -109,6 +112,9 @@ protected:
 					vray
 				);
 				abcInstance->meshInstance=geom->newInstance(params);
+				if (gEnvARRRI.getValue()) {
+					VR::registerRenderInstance2(vray, geom, renderID, mtlPlugin, userAttr);
+				}
 			}
 		}
 	}
@@ -210,6 +216,7 @@ void GeomAlembicReader::deleteInstance(VRayStaticGeometry *instance) {
 }
 
 void GeomAlembicReader::preRenderBegin(VR::VRayRenderer *vray) {
+	gEnvARRRI.resetValue();
 	VRayPluginRendererInterface *pluginRenderer=(VRayPluginRendererInterface*) GET_INTERFACE(vray, EXT_PLUGIN_RENDERER);
 	if (!pluginRenderer) return; // Don't know how to modify the scene
 	plugman=pluginRenderer->getPluginManager();

--- a/src/geomalembicreader.cpp
+++ b/src/geomalembicreader.cpp
@@ -10,7 +10,7 @@ struct GeomAlembicReaderInstance: VRayStaticGeometry {
 	}
 
 	void compileGeometry(VR::VRayRenderer *vray, const VR::Transform *_tm, double *_times, int _tmCount) VRAY_OVERRIDE {
-		createMeshInstances(renderID, NULL, NULL, Transform(1), objectID, userAttrs.ptr(), primaryVisibility);
+		createMeshInstances(vray, renderID, NULL, NULL, Transform(1), objectID, userAttrs.ptr(), primaryVisibility);
 
 		const VRayFrameData &fdata=vray->getFrameData();
 
@@ -84,7 +84,7 @@ protected:
 		return static_cast<BSDFInterface*>(GET_INTERFACE(mtl, EXT_BSDF));
 	}
 
-	void createMeshInstances(int renderID, VolumetricInterface *volume, LightList *lightList, const Transform &baseTM, int objectID, const tchar *userAttr, int primaryVisibility) {
+	void createMeshInstances(VRayRenderer* vray, int renderID, VolumetricInterface *volume, LightList *lightList, const Transform &baseTM, int objectID, const tchar *userAttr, int primaryVisibility) {
 		int numInstances=reader->meshInstances.count();
 		for (int i=0; i<numInstances; i++) {
 			AlembicMeshInstance *abcInstance=reader->meshInstances[i];
@@ -96,7 +96,19 @@ protected:
 			StaticGeomSourceInterface *geom=static_cast<StaticGeomSourceInterface*>(GET_INTERFACE(geomPlugin, EXT_STATIC_GEOM_SOURCE));
 			if (geom) {
 				VRayPlugin *mtlPlugin=reader->getMaterialPluginForInstance(abcInstance->abcName);
-				abcInstance->meshInstance=geom->newInstance(getMaterial(mtlPlugin), getBSDF(mtlPlugin), renderID, NULL, lightList, baseTM, objectID, userAttr, primaryVisibility);
+				NewInstanceParameters params(
+					getMaterial(mtlPlugin),
+					getBSDF(mtlPlugin),
+					renderID,
+					NULL,
+					lightList,
+					baseTM,
+					objectID,
+					userAttr,
+					primaryVisibility,
+					vray
+				);
+				abcInstance->meshInstance=geom->newInstance(params);
 			}
 		}
 	}
@@ -183,6 +195,10 @@ VRayStaticGeometry* GeomAlembicReader::newInstance(
 	abcReaderInstance->setPrimaryVisibility(primaryVisibility);
 	abcReaderInstance->setUserAttrs(userAttr);
 	return abcReaderInstance;
+}
+
+VRayStaticGeometry* GeomAlembicReader::newInstance(const NewInstanceParameters &params) {
+	return this->newInstance(params.mtl, params.bsdf, params.renderID, params.volume, params.lightList, params.baseTM, params.objectID, params.userAttributes, params.primaryVisibility);
 }
 
 void GeomAlembicReader::deleteInstance(VRayStaticGeometry *instance) {

--- a/src/geomalembicreader.cpp
+++ b/src/geomalembicreader.cpp
@@ -1,12 +1,9 @@
 #include "geomalembicreader.h"
-#include "getenvvars.h"
 
 using namespace VR;
 
 //*************************************************************
 // GeomAlembicReaderInstance
-
-static VR::GetEnvVarInt gEnvARRRI("ARRRI", 0);
 
 struct GeomAlembicReaderInstance: VRayStaticGeometry {
 	GeomAlembicReaderInstance(GeomAlembicReader *abcReader):reader(abcReader) {
@@ -112,9 +109,7 @@ protected:
 					vray
 				);
 				abcInstance->meshInstance=geom->newInstance(params);
-				if (gEnvARRRI.getValue()) {
-					VR::registerRenderInstance2(vray, geom, renderID, mtlPlugin, userAttr);
-				}
+				VR::registerRenderInstance2(vray, geom, renderID, mtlPlugin, userAttr);
 			}
 		}
 	}
@@ -216,7 +211,6 @@ void GeomAlembicReader::deleteInstance(VRayStaticGeometry *instance) {
 }
 
 void GeomAlembicReader::preRenderBegin(VR::VRayRenderer *vray) {
-	gEnvARRRI.resetValue();
 	VRayPluginRendererInterface *pluginRenderer=(VRayPluginRendererInterface*) GET_INTERFACE(vray, EXT_PLUGIN_RENDERER);
 	if (!pluginRenderer) return; // Don't know how to modify the scene
 	plugman=pluginRenderer->getPluginManager();

--- a/src/geomalembicreader.h
+++ b/src/geomalembicreader.h
@@ -499,6 +499,9 @@ struct GeomAlembicReader: VR::VRayStaticGeomSource, VR::VRaySceneModifierInterfa
 		const tchar *userAttr,
 		int primaryVisibility
 	) VRAY_OVERRIDE;
+
+	VUtils::VRayStaticGeometry* newInstance(const VUtils::NewInstanceParameters &params) override;
+
 	void deleteInstance(VR::VRayStaticGeometry *instance) VRAY_OVERRIDE;
 
 	// From VRayPlugin

--- a/src/geomalembicreader.h
+++ b/src/geomalembicreader.h
@@ -94,10 +94,10 @@ struct AnimatedParam: VR::VRayPluginParameter {
 protected:
 	const tchar *paramName;
 
-	template<class T>
+	template<class U>
 	struct Keyframe {
 		double time;
-		T data;
+		U data;
 
 		Keyframe(void):time(0.0f) {}
 
@@ -138,11 +138,11 @@ struct AnimatedSimpleListParam: AnimatedParam<T> {
 	AnimatedSimpleListParam(const tchar *name):AnimatedParam<T>(name) {}
 
 	int getCount(double time) VRAY_OVERRIDE {
-		int keyframeIdx=getKeyframeIndex(time);
+		int keyframeIdx=this->getKeyframeIndex(time);
 		if (keyframeIdx==-1)
 			return -1;
 
-		return keyframes[keyframeIdx].data.count();
+		return this->keyframes[keyframeIdx].data.count();
 	}
 };
 


### PR DESCRIPTION
* Call registerRenderInstance2 to make instances known to cryptomatte
* Fix compilation with GCC
* Fix a forgotten comma in ignoredPlugins list
* Add newInstance override required for building with V-Ray 5 SDK